### PR TITLE
Re-resolve streams of THIS-CONSOLE-APPENDER instances in INIT-HOOK

### DIFF
--- a/src/appender.lisp
+++ b/src/appender.lisp
@@ -29,7 +29,7 @@
   '())
 
 (defun log-appender-disabled (appender condition)
-  (ignore-errors 
+  (ignore-errors
    (log-error :logger +self-meta-logger+ "~@<Caught ~S ~:_~A ~_~
                                              Appender ~S disabled~:>"
               (type-of condition) condition appender)))
@@ -92,11 +92,11 @@ ADD-WATCH-TOKEN"))
   '((:immediate-flush immediate-flush boolean)
     (:flush-interval flush-interval number)))
 
-(defgeneric appender-stream (appender) 
+(defgeneric appender-stream (appender)
   (:documentation "Should return the stream to which appender will write log messages"))
 
 (defclass fixed-stream-appender-base (stream-appender)
-  ((stream :accessor appender-stream) 
+  ((stream :accessor appender-stream)
    (stream-owner :initarg :stream-owner :initform nil))
   (:documentation "Appender that writes message to the stream in STREAM slot"))
 
@@ -113,7 +113,7 @@ STREAM slot."))
   (append (call-next-method)
           '((:stream stream :symbol-value))))
 
-(defclass console-appender (stream-appender) () 
+(defclass console-appender (stream-appender) ()
   (:documentation "A stream appender that writes messages to
 *TERMINAL-IO* stream, which must be a synonym stream"))
 
@@ -128,8 +128,10 @@ To capture the target output stream, any chain of SYNONYM-STREAM or
 TWO-WAY-STREAM is followed recursively, until result is no longer
 either synonym or two way stream"))
 
-(defmethod initialize-instance :after ((a this-console-appender) &key &allow-other-keys)
-  (with-slots (stream) a
+(defmethod shared-initialize :after ((instance this-console-appender)
+				     (slot-names t)
+				     &key &allow-other-keys)
+  (with-slots (stream) instance
     (setf stream (resolve-stream stream))))
 
 (defclass tricky-console-appender (this-console-appender) ()
@@ -300,7 +302,7 @@ its no longer attached to loggers"))
   (maybe-close-stream appender))
 
 (defclass file-appender (file-appender-base)
-  ((filename :initarg :file :reader appender-filename)) 
+  ((filename :initarg :file :reader appender-filename))
   (:documentation "Appender that writes to a file with a fixed file
 name"))
 
@@ -316,7 +318,7 @@ to rollover the log file.
 
 Properties:
 
-ROLLOVER-CHECK-PERIOD 
+ROLLOVER-CHECK-PERIOD
 
 : An integer, when current time advances past the boundary evenly divisible by this
 number a call to MAYBE-ROLL-FILE will be made to check if log file needs
@@ -452,7 +454,7 @@ weekly backup, that is appended to each day")
       (setf %last-backup-name backup-filename)
       (call-next-method))))
 
-(defmethod maybe-roll-file ((appender daily-file-appender)) 
+(defmethod maybe-roll-file ((appender daily-file-appender))
   "Expands FILENAME and BACKUP patterns, and if one of them changed,
 switches to the new log file"
   (with-slots (name-format backup-name-format
@@ -474,11 +476,11 @@ switches to the new log file"
       ;; Normal code path
       (let ((new-bak (expand-name-format
                       (or backup-name-format name-format)
-                      time utc-p))) 
+                      time utc-p)))
         (unless (and (equal new-file %current-file-name)
                      (equal new-bak %next-backup-name))
-          (when %current-file-name 
-            (maybe-close-stream appender) 
+          (when %current-file-name
+            (maybe-close-stream appender)
             (unless (equal %current-file-name %next-backup-name)
               (backup-log-file appender %current-file-name %next-backup-name)))
           (setq %current-file-name new-file
@@ -486,13 +488,13 @@ switches to the new log file"
 
 
 (defmethod handle-appender-error ((a temp-appender) c)
-  (cond ((typep c (temp-appender-error-type a)) 
+  (cond ((typep c (temp-appender-error-type a))
          (let ((loggers (appender-loggers a)))
-           (ignore-errors 
+           (ignore-errors
             (log-error :logger +self-meta-logger+ "~@<Caught ~S ~:_~A ~_~
                                                     Removing ~S ~_from ~
                                                    ~{~S~^, ~:_~}~:>"
-                       (type-of c) c a loggers))) 
+                       (type-of c) c a loggers)))
          (dolist (l (appender-loggers a))
            (remove-appender l a))
          :ignore)

--- a/src/watcher.lisp
+++ b/src/watcher.lisp
@@ -34,6 +34,20 @@
   #+sb-thread `(sb-sys:with-local-interrupts ,@body)
   #-sb-thread`(progn ,@body))
 
+(defun call-with-logged-problems (context thunk)
+  (handler-case (funcall thunk)
+    (error (condition)
+      (log-error :logger +self-meta-logger+
+                 "~@<Caught ~S during ~S: ~A; Continuing.~@:>"
+                 (type-of condition) context condition))
+    (warning (condition)
+      (log-warn :logger +self-meta-logger+
+                "~@<Caught ~S during configuration: ~A; Continuing.~@:>"
+                (type-of condition) context condition))))
+
+(defmacro with-logged-problems (context &body body)
+  `(call-with-logged-problems ',context (lambda () ,@body)))
+
 (defun start-hierarchy-watcher-thread ()
   (unless *watcher-thread*
     (let ((logger (make-logger '(log4cl))))
@@ -92,8 +106,10 @@
 (defun stop-hierarchy-watcher-thread ()
   (let ((thread (with-hierarchies-lock *watcher-thread*)))
     (when thread
-      (ignore-errors (bt::destroy-thread thread))
-      (ignore-errors (bt:join-thread thread)))))
+      (with-logged-problems '(stop-hierarchy-watcher-thread :destroy-thread)
+        (bt::destroy-thread thread))
+      (with-logged-problems '(stop-hierarchy-watcher-thread :join-thread)
+        (bt:join-thread thread)))))
 
 (defun maybe-start-watcher-thread ()
   (with-hierarchies-lock
@@ -108,22 +124,28 @@
 
 (defun save-hook ()
   "Flushes all existing appenders, and stops watcher thread"
-  (ignore-errors (flush-all-appenders))
-  (ignore-errors (save-all-appenders))
-  (ignore-errors (stop-hierarchy-watcher-thread)))
+  (with-logged-problems (save-hook :flush-all-appenders)
+    (flush-all-appenders))
+  (with-logged-problems (save-hook :flush-all-appenders)
+    (save-all-appenders))
+  (with-logged-problems (save-hook :stop-hierarch-watcher-thread)
+    (stop-hierarchy-watcher-thread)))
 
 (defun exit-hook ()
   "Flushes all existing appenders"
-  (ignore-errors (flush-all-appenders)))
+  (with-logged-problems (exit-hook :flush-all-appenders)
+    (flush-all-appenders)))
 
 (defun init-hook ()
   "Starts watcher thread if any existing appenders don't
 have :immediate-flush option"
-  (ignore-errors (maybe-start-watcher-thread))
-  (ignore-errors (dolist (appender (all-appenders))
-                   (when (typep appender 'this-console-appender)
-                     (setf (slot-value appender 'stream) *global-console*)
-                     (reinitialize-instance appender)))))
+  (with-logged-problems (init-hook :maybe-start-watch-thread)
+    (maybe-start-watcher-thread))
+  (with-logged-problems (init-hook :reinitialize-this-console-appender)
+    (dolist (appender (all-appenders))
+      (when (typep appender 'this-console-appender)
+        (setf (slot-value appender 'stream) *global-console*)
+        (reinitialize-instance appender)))))
 
 (defun all-appenders (&optional (all-hierarchies t))
   "Return all existing appenders in all hierarchies"


### PR DESCRIPTION
`this-console-appender` "resolves" its stream, obtaining an `fd-stream`, at initialization time. In SBCL, such a `fd-stream` becomes invalid after image save/restart. Using such an invalid `fd-stream` can lead to "Bad file descriptor" errors:

```
$ sbcl --noinform --no-userinit \
  --load ~/.local/share/common-lisp/quicklisp/setup.lisp \
  --eval '(ql:quickload :log4cl)' \
  --eval '(defun f () (log:info "bla"))' \
  --eval '(save-lisp-and-die "bla" :executable t :toplevel (quote f))'
[...]
$ ./bla
 <INFO> [15:22:07] cl-user (f) - bla
ERROR - Caught SB-INT:SIMPLE-STREAM-ERROR
        Couldn't write to #<SB-SYS:FD-STREAM for "the terminal" {1000247223}>:
          Bad file descriptor
        Removing #<LOG4CL-IMPL:TRICKY-CONSOLE-APPENDER {10023EA193}>
        from #<LOGGER +ROOT+ {1000630413}>
```

and even memory corruption.

This patch extends `init-hook` to re-resolve `this-console-appender` streams and adds logging of errors to init/save/exit hooks.
