### PR TITLE
Syslog Appender

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,15 +1,22 @@
-## 1.1.2 - Bugfixes 
+## 1.1.3 - Syslog Appender
+
+* For SBCL, a syslog appender using sb-posix:syslog has been added.
+
+* Other implementations may be supported once cl-syslog becomes
+  available with the next Quicklisp release.
+
+## 1.1.2 - Bugfixes
 
 * Re-initialize any appenders that remember the resolved stream in INIT-HOOK on
   SBCL; which fixes a crash if SBCL dump is ressurected without doing
   (CLEAR-LOGGING-CONFIGURATION). Patch by Jan Moringen.
-  
+
 * Add (log:config ...adding an appender... :filter LEVEL) option, which causes
   appender to drop messages less serious then LEVEL. This allows one to
   configure per-level appenders, for example error.log and debug.log. Patch by
   https://github.com/naryl
 
-## 1.1.1 - Log4Slime 
+## 1.1.1 - Log4Slime
 
 * LOG:CONFIG :thread or :ndc argument can be followed by two numbers,
   which will be used as MIN/MAX width fields, this helps if you want
@@ -18,10 +25,10 @@
 * Pattern layout can use {pretty}{100} to set **PRINT-RIGHT-MARGIN** in
   addition to forcing pretty printing.
 
-* (LOG:CONFIG (LOG:CATEGORY) ...) from top level now configures the package logger 
-  instea of package.<sourcefile> logger. 
+* (LOG:CONFIG (LOG:CATEGORY) ...) from top level now configures the package logger
+  instea of package.<sourcefile> logger.
 
-* :console appender changed back to use **DEBUG-IO** instead of 
+* :console appender changed back to use **DEBUG-IO** instead of
   **TERMINAL-IO**, because on LispWorks **TERMINAL-IO** goes to actual
   terminal.
 
@@ -35,12 +42,12 @@
   if category name contained % character.
 
 * %t and %h pattern layout (displaying thread and host name) were crashing
-  if corresponding attribute was actually NIL (apparently its possible to 
+  if corresponding attribute was actually NIL (apparently its possible to
   do create SBCL thread with NIL name)
 
 * (LOG:CONFIG :daily ...) now accepts pathnames again
 
-## 1.1.0 - Log4Slime 
+## 1.1.0 - Log4Slime
 
 * Log4CL now has Slime/Emacs integration, which is available in a
   system :log4slime. It colorizes the log output, and provides
@@ -81,7 +88,7 @@
   is automatically terminated on exit, and before SAVE-LISP-AND-DIE.
 
 * Added API to flush all appenders, LOG4CL:FLUSH-ALL-APPENDERS, which
-  is automatically called on SBCL from exit hooks. 
+  is automatically called on SBCL from exit hooks.
 
 * (LOG:CONFIG) now has many new pattern layout related options
   :pretty, :nopretty, :file, :file2, :nofile, :time, :notime, :package

--- a/log4cl.asd
+++ b/log4cl.asd
@@ -19,7 +19,7 @@
 (in-package :log4cl.system)
 
 (defsystem :log4cl
-  :version "1.1.2"
+  :version "1.1.3"
   :depends-on (:bordeaux-threads)
   :components
   ((module "src" :serial t
@@ -38,6 +38,8 @@
                               (:file "simple-layout")
                               (:file "pattern-layout")
                               (:file "appender")
+                              (:file "syslog-appender-sbcl"
+                               :if-feature :sbcl)
                               (:file "watcher")
                               (:file "configurator")
                               (:file "property-parser")
@@ -45,7 +47,7 @@
                               (:file "package")))))
 
 (defsystem :log4cl-test
-  :version "1.1.2"
+  :version "1.1.3"
   :depends-on (:log4cl :stefil)
   :components ((:module "tests"
                 :serial t
@@ -73,7 +75,3 @@
       (when foo
         (funcall foo))))
   (values))
-
-
-
-

--- a/src/impl-package.lisp
+++ b/src/impl-package.lisp
@@ -55,14 +55,14 @@
                     ;; sexp version of logging macros
                     #:log-sexp-fatal #:log-sexp-error #:log-sexp-warn #:log-sexp-info #:log-sexp-debug #:log-sexp-trace
                     #:log-sexp-debu1 #:log-sexp-debu2 #:log-sexp-debu3 #:log-sexp-debu4 #:log-sexp-debu5 #:log-sexp-debu6
-                    #:log-sexp-debu7 #:log-sexp-debu8 #:log-sexp-debu9 
+                    #:log-sexp-debu7 #:log-sexp-debu8 #:log-sexp-debu9
                     #:log-indented
                     ;; logger access functions
                     #:make-log-level #:make-logger
                     #:set-log-level
                     #:logger-parent
                     #:logger-log-level
-                    #:logger-appenders 
+                    #:logger-appenders
                     #:effective-log-level
                     #:effective-appenders
                     #:add-appender
@@ -91,7 +91,7 @@
                     #:in-log-hierarchy
                     #:with-package-log-hierarchy
                     #:in-package-log-hierarchy
-                    ;; layouts & appenders 
+                    ;; layouts & appenders
                     #:layout
                     #:layout-to-stream
                     #:appender-do-append
@@ -141,7 +141,7 @@
                     #:logger-descendants
                     #:map-logger-children
                     #:map-logger-descendants
-                    #:start-hierarchy-watcher-thread 
+                    #:start-hierarchy-watcher-thread
                     #:stop-hierarchy-watcher-thread
                     #:add-watch-token
                     #:remove-watch-token
@@ -198,7 +198,8 @@
                     #:%get-logger
                     #:with-package-naming-configuration
                     #:fix-method-spec-list
-                    #:tricky-console-appender))
+                    #:tricky-console-appender
+                    #+sbcl #:syslog-appender))
                 ;; avoid SBCL (also exports) error
                 (removed-exports
                   (set-difference old-exports
@@ -214,6 +215,3 @@
              (unexport removed-exports p2))
            defpackage-form))))
   (%define-log4cl-package))
-
-
-

--- a/src/syslog-appender-sbcl.lisp
+++ b/src/syslog-appender-sbcl.lisp
@@ -1,0 +1,72 @@
+;;; -*- Mode: Lisp; Syntax: ANSI-Common-Lisp; Base: 10 -*-
+;;;
+;;; Copyright (c) 2013, 2014, Jan Moringen. All rights reserved.
+;;;
+;;; This file is licensed to You under the Apache License, Version 2.0
+;;; (the "License"); you may not use this file except in compliance
+;;; with the License.  You may obtain a copy of the License at
+;;; http://www.apache.org/licenses/LICENSE-2.0
+;;;
+;;; Unless required by applicable law or agreed to in writing, software
+;;; distributed under the License is distributed on an "AS IS" BASIS,
+;;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;;; See the License for the specific language governing permissions and
+;;; limitations under the License.
+
+(in-package #:log4cl)
+
+(defclass syslog-appender (appender)
+  ((name :initarg :name :type string)
+   (include-pid? :initarg :include-pid? :type boolean))
+  (:default-initargs
+   :layout (make-instance 'pattern-layout :conversion-pattern "%m"))
+  (:documentation
+   "An appender that writes log messages to the syslog.
+
+The identity of the syslog connection is controlled by the :name
+initarg and defaults to
+
+  (lisp-implementation-type)
+
+The :include-pid? initarg controls whether log entries produced by the
+syslog connection should include the process id (PID). The default is
+true."))
+
+(defmethod shared-initialize :after ((instance   syslog-appender)
+                                     (slot-names t)
+                                     &key
+                                     (name         (lisp-implementation-type))
+                                     (include-pid? t))
+  (sb-posix:openlog name (logior sb-posix:log-user
+                                 (if include-pid? sb-posix:log-pid 0))))
+
+(defmethod reinitialize-instance :before ((instance syslog-appender) &key)
+  (sb-posix:closelog))
+
+(defmethod close-appender ((appender syslog-appender))
+  (sb-posix:closelog))
+
+(defmethod appender-do-append ((appender syslog-appender) logger level log-func)
+  (let* ((syslog-level (%log4cl-level->syslog-level level))
+         (layout       (appender-layout appender))
+         (message
+           (with-output-to-string (stream)
+             (layout-to-stream layout stream logger level log-func))))
+    (sb-posix:syslog syslog-level "~A" message)))
+
+(defmethod property-alist ((instance syslog-appender))
+  (append (call-next-method)
+          '((:name name :string-skip-whitespace)
+            (:include-pid? include-pid? boolean))))
+
+;; Utility functions
+
+(defun %log4cl-level->syslog-level (level)
+  (let ((level/keyword (aref +log-level-to-keyword+ level)))
+    (ecase level/keyword
+      (:fatal sb-posix:log-crit)
+      (:error sb-posix:log-err)
+      (:warn  sb-posix:log-warning)
+      (:info  sb-posix:log-info)
+      ((:debu1 :debu2 :debu3 :debu4 :debu5 :debu6 :debu7 :debu8 :debu9)
+       sb-posix:log-debug))))

--- a/tests/log4cl.properties
+++ b/tests/log4cl.properties
@@ -1,10 +1,10 @@
 # Copyright (c) 2012, Max Mikhanosha. All rights reserved.
-# 
+#
 # This file is licensed to You under the Apache License, Version 2.0
 # (the "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,12 +13,14 @@
 
 
 log4cl:rootLogger = INFO, file1, console
+#, syslog1
 log4cl:appender:console = log4cl:console-appender
 log4cl:appender:console:layout = log4cl:pattern-layout
 log4cl:appender:console:layout:conversion-pattern =|%p| |%c| - %m%n
 log4cl:appender:file1 = log4cl:file-appender
 log4cl:appender:file1:file = /tmp/logfile.txt
 log4cl:appender:file1:immediate-flush = true
-
-
-
+#log4cl:appender:syslog1 = log4cl:syslog-appender
+#log4cl:appender:syslog1:name = myprogram
+#log4cl:appender:syslog1:layout = log4cl:pattern-layout
+#log4cl:appender:syslog1:layout:conversion-pattern =%p %m


### PR DESCRIPTION
The syslog appender is SBCL-only for now, but once mmaul/cl-syslog becomes available via Quicklisp, a port should be easy.

Can be tested like this:

``` cl
CL-USER> (log4cl:add-appender log4cl:*root-logger* (make-instance 'log4cl:syslog-appender))
CL-USER> (log:info "bla")
```
