### PR TITLE
Specialize args LOGGER, LOG-FUNC on T to eliminate unused warnings.

### DIFF
--- a/src/appender-base.lisp
+++ b/src/appender-base.lisp
@@ -92,7 +92,7 @@ Example:
    (values))
 
 Return value of this function is ignored")
-  (:method :around ((appender appender) logger level log-func)
+  (:method :around ((appender appender) (logger t) level (log-func t))
     (let ((filter (appender-filter appender)))
       (when (or (not filter)
                 (>= filter level))


### PR DESCRIPTION
Eliminates warnings before this change that look something like

;Compiler warnings for "home:lisp;quicklisp;local-projects;log4cl;src;appender-base.lisp.newest" :
;   In (APPENDER-DO-APPEND :AROUND (APPENDER T T T)) inside an anonymous lambda form: Unused lexical variable LOGGER
;   In (APPENDER-DO-APPEND :AROUND (APPENDER T T T)) inside an anonymous lambda form: Unused lexical variable LOG-FUNC
; Warning: Lisp compilation had style-warnings while compiling #<CL-SOURCE-FILE "log4cl" "src" "appender-base">
